### PR TITLE
Cleaned up game over handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ been used throughout the code:
     - solution: an array of one or more answers cards from one player.
     - judge: the player that chooses the best solution from the other players.
     - host: the player that creates, configures, and launches the game.
+
+## To Do:
+- Add alert that leaving the Play Game window will exit the game.
+- Clean up CAH fit of multiple cards in solution on mobile.
+- Check into using a "text fit" library to better fit card text.
+- Create design notes diagram.

--- a/app/server.js
+++ b/app/server.js
@@ -109,8 +109,6 @@ io.on('connection', function(socket) {
     console.log('io.connection: ' + socket.id);
     //console.dir(socket);
 
-    socket.emit('test', {testData: 123});
-
     // Create a Player object for the existing socket.
     gameList.createPlayer(socket);
 

--- a/public/join_game.html
+++ b/public/join_game.html
@@ -34,7 +34,8 @@
     <div ng-show="jgc.hostPlayerIndex === jgc.mePlayerIndex">
         <h2>When you have named the game,</h2>
         <h2>and all players have joined:</h2>
-        <button class="launch-game-button" ng-disabled="!jgc.gameName || (jgc.playerList.length < 3)" ng-click="jgc.onLaunchButton()">Launch The Game</button>
+        <button class="launch-game-button" ng-disabled="jgc.gameOver || !jgc.gameName || (jgc.playerList.length < 3)"
+                ng-click="jgc.onLaunchButton()">Launch The Game</button>
     </div>
     <div ng-show="jgc.hostPlayerIndex !== jgc.mePlayerIndex">
         <h2>Waiting for host to launch the game</h2>

--- a/public/new_game.html
+++ b/public/new_game.html
@@ -27,5 +27,6 @@
     <hr>
     <h2>When you have named the game,</h2>
     <h2>and all players have joined:</h2>
-    <button class="launch-game-button" ng-disabled="!ngc.gameName || (ngc.playerList.length < 3)" ng-click="ngc.onLaunchButton()">Launch The Game</button>
+    <button class="launch-game-button" ng-disabled="ngc.gameOver || !ngc.gameName || (ngc.playerList.length < 3)"
+            ng-click="ngc.onLaunchButton()">Launch The Game</button>
 </div>


### PR DESCRIPTION
- Added server game flags for gameLaunched and gameOver.
- Disabled REST interface showing games that are launched or over; they cannot be joined.
- Changed to send out a single game over as players leave, and eliminate sending multiple messages.
- Changed Choose Game controller to disconnect if connected, to handle browser "back" to this page.
- Made a separate server function for removePlayerFromGame, now called in multiple places.
- Protected against some message processing race conditions while shutting down game.
- Added alert pop-up for disconnect or Game Over in New Game and Join Game pages.
- Added alert pop-up for JoinFailed message to make sure the user sees this.
- Removed archaic test message.